### PR TITLE
BL-13236 Add support for using proxy while fetching Cognito public keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@types/jsonwebtoken": "^8.5.4",
         "aws-lambda": "^1.0.6",
+        "https-proxy-agent": "^5.0.0",
         "iam-policy-generator": "^1.3.2",
         "jsonwebtoken": "^8.5.1",
         "jwks-rsa": "^2.0.3"
@@ -2341,7 +2342,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "dependencies": {
         "debug": "4"
       },
@@ -5465,7 +5465,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -13151,7 +13150,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dev": true,
       "requires": {
         "debug": "4"
       }
@@ -15619,7 +15617,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
       "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-      "dev": true,
       "requires": {
         "agent-base": "6",
         "debug": "4"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "@types/jsonwebtoken": "^8.5.4",
     "aws-lambda": "^1.0.6",
+    "https-proxy-agent": "^5.0.0",
     "iam-policy-generator": "^1.3.2",
     "jsonwebtoken": "^8.5.1",
     "jwks-rsa": "^2.0.3"
@@ -36,8 +37,8 @@
     "archiver": "^5.3.0",
     "aws-sam-webpack-plugin": "^0.9.0",
     "current-git-branch": "^1.1.0",
-    "eslint-import-resolver-typescript": "^2.4.0",
     "eslint": "^7.6.0",
+    "eslint-import-resolver-typescript": "^2.4.0",
     "fs-extra": "^10.0.0",
     "jest": "^26.6.3",
     "mock-jwks": "^1.0.1",
@@ -47,9 +48,9 @@
     "ts-loader": "^8.3.0",
     "typescript": "^3.9.10",
     "uuid": "^8.3.2",
+    "webpack": "^5.44.0",
     "webpack-cli": "^4.7.2",
-    "webpack-merge": "^5.8.0",
-    "webpack": "^5.44.0"
+    "webpack-merge": "^5.8.0"
   },
   "engines": {
     "node": "^14.17.3"

--- a/tests/services/cognito.proxy.test.ts
+++ b/tests/services/cognito.proxy.test.ts
@@ -1,0 +1,48 @@
+import JwksClient from 'jwks-rsa';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { Cognito } from '../../src/services/cognito';
+import { Logger } from '../../src/util/logger';
+
+jest.mock('../../src/util/logger');
+jest.mock('jwks-rsa', () => ({
+  __esModule: true,
+  default: jest.fn().mockReturnThis(),
+  getSigningKey: jest.fn().mockReturnValue({ getPublicKey: () => jest.fn() }),
+}));
+
+describe('Cognito service with proxy settings', () => {
+  const oldEnvCache = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    // Reset the env variables.
+    process.env = { ...oldEnvCache };
+  });
+
+  afterAll(() => {
+    process.env = oldEnvCache; // Restore old environment
+  });
+
+  test('getPublicKey() should apply proxy if `HTTP_PROXY` environment variable set', async () => {
+    const logger = new Logger('');
+    const cognito = new Cognito('region', 'pool_id', ['client_id'], logger);
+
+    process.env.HTTP_PROXY = 'http://example.com';
+
+    await cognito.getPublicKey('KEY_ID');
+
+    // Define expectations
+    expect(JwksClient).toBeCalledWith(expect.objectContaining({ requestAgent: expect.any(HttpsProxyAgent) as unknown }));
+  });
+
+  test('getPublicKey() should apply not proxy if `HTTP_PROXY` environment variable set', async () => {
+    const logger = new Logger('');
+    const cognito = new Cognito('region', 'pool_id', ['client_id'], logger);
+
+    await cognito.getPublicKey('KEY_ID');
+
+    // Define expectations
+    expect(JwksClient).toBeCalledWith(expect.objectContaining({ requestAgent: undefined }));
+  });
+});


### PR DESCRIPTION
## Description

Add support for proxy, if set in the environment variables via. `HTTP_PROXY`.

Related issue: [BL-13236](https://jira.dvsacloud.uk/browse/BL-13236)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works