### PR TITLE
feat: add ability to allow path parameters in config routes

### DIFF
--- a/src/services/policyGenerator.ts
+++ b/src/services/policyGenerator.ts
@@ -77,13 +77,7 @@ export class PolicyGenerator {
         && roleConfig.authorisedEndpoints.some((ep) => {
           if (ep.httpVerb !== httpVerb) return false;
 
-          // Handle wildcard paths
-          if (ep.url.endsWith('*')) {
-            // remove '*'
-            const basePath = ep.url.slice(0, -1);
-            return requestPath.startsWith(basePath);
-          }
-          return ep.url === requestPath;
+          return this.matchesUrlPattern(ep.url, requestPath);
         }));
 
     this.logger.info(`User ${isAllowed ? '' : 'not '}authorised to access ${requestPath} with the roles: ${JSON.stringify(userRoles)}`);
@@ -132,6 +126,27 @@ export class PolicyGenerator {
       Action: this.INVOKE_ACTION,
       Resource: arn,
     };
+  }
+
+  /**
+   * Tests whether a request path matches a URL pattern from the config.
+   * Supports two dynamic segment types:
+   *  - `:paramName` — matches any single path segment (e.g. `:licenceNumber` matches "OB1234567")
+   *  - `*`          — matches anything that follows, including multiple segments
+   */
+  private matchesUrlPattern(configUrl: string, requestPath: string): boolean {
+    const configUrlSegments = configUrl.split('/');
+    const requestSegments = requestPath.split('/');
+
+    for (let i = 0; i < configUrlSegments.length; i++) {
+      const configUrlSegment = configUrlSegments[`${i}`];
+
+      if (configUrlSegment === '*') return true;
+      if (i >= requestSegments.length) return false;
+      if (!configUrlSegment.startsWith(':') && configUrlSegment !== requestSegments[`${i}`]) return false;
+    }
+
+    return configUrlSegments.length === requestSegments.length;
   }
 
   private generateWildcardArn(eventMethodArn: string): string {

--- a/tests/services/policyGenerator.test.ts
+++ b/tests/services/policyGenerator.test.ts
@@ -31,6 +31,18 @@ describe('PolicyGenerator', () => {
         },
       ],
     },
+    {
+      role: 'ThirdRole',
+      authorisedEndpoints: [
+        {
+          httpVerb: 'GET',
+          url: '/endpoint/:id/detail',
+        }, {
+          httpVerb: 'GET',
+          url: '/endpoint/files/*',
+        },
+      ],
+    },
   ];
 
   beforeEach(() => {
@@ -123,11 +135,39 @@ describe('PolicyGenerator', () => {
 
       expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Allow');
       expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
-      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/one');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
     });
 
     test('should return a deny policy if a user is trying to access an ARN with the incorrect role', () => {
       const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/one';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['UnknownRole'], requestArn);
+
+      expect(result.principalId).toBe('Unauthorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Deny');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return an allow policy when a dynamic :param segment matches any value', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/abc123/detail';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['ThirdRole'], requestArn);
+
+      expect(result.principalId).toBe('Authorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Allow');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return a deny policy when the HTTP verb does not match a :param route', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/POST/endpoint/abc123/detail';
       const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['ThirdRole'], requestArn);
 
       expect(result.principalId).toBe('Unauthorised');
@@ -137,7 +177,77 @@ describe('PolicyGenerator', () => {
 
       expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Deny');
       expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
-      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/one');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return a deny policy when the path has extra segments beyond a :param route', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/abc123/detail/extra';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['ThirdRole'], requestArn);
+
+      expect(result.principalId).toBe('Unauthorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Deny');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return an allow policy when a wildcard matches a single trailing segment', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/files/report';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['ThirdRole'], requestArn);
+
+      expect(result.principalId).toBe('Authorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Allow');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return an allow policy when a wildcard matches multiple trailing segments', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/files/report/summary';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['ThirdRole'], requestArn);
+
+      expect(result.principalId).toBe('Authorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Allow');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return a deny policy when the path prefix before the wildcard does not match', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/other/report';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['ThirdRole'], requestArn);
+
+      expect(result.principalId).toBe('Unauthorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Deny');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
+    });
+
+    test('should return an allow policy when one of multiple user roles matches', () => {
+      const requestArn = 'arn:aws:execute-api:eu-west-2:123456789012:/*/GET/endpoint/one';
+      const result: APIGatewayAuthorizerResult = policyGenerator.generateConfigurationFilePolicyForProxy(PERMISSIONS_CONFIG, ['UnknownRole', 'FirstRole'], requestArn);
+
+      expect(result.principalId).toBe('Authorised');
+      expect(result.policyDocument.Version).toBe('2012-10-17');
+
+      expect(result.policyDocument.Statement).toHaveLength(1);
+
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Effect', 'Allow');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Action', 'execute-api:Invoke');
+      expect(result.policyDocument.Statement[0]).toHaveProperty('Resource', requestArn);
     });
   });
 });


### PR DESCRIPTION
## Description
This pull request enhances the authorisation logic in the `PolicyGenerator` service by introducing more flexible URL pattern matching for endpoint authorisation. It adds support for dynamic path segments (e.g., `:id`) and wildcards (`*`), allowing for more expressive and maintainable permission configurations. Comprehensive tests have been added to verify these new matching capabilities and ensure correct policy behaviour.

**Authorisation logic improvements:**

* Refactored the endpoint matching logic in `PolicyGenerator` to use a new `matchesUrlPattern` method, enabling support for dynamic `:param` segments and trailing wildcards (`*`) in URL patterns. This allows endpoint definitions to match a wider variety of request paths. [[1]](diffhunk://#diff-4c16cb5ff8f3aa89e97d9138bd5963764c35dd3cc3b5ed3585c2731398392e5cL80-R80) [[2]](diffhunk://#diff-4c16cb5ff8f3aa89e97d9138bd5963764c35dd3cc3b5ed3585c2731398392e5cR131-R151)

**Test coverage enhancements:**

* Expanded the test configuration and added multiple test cases in `policyGenerator.test.ts` to cover scenarios with dynamic segments and wildcards, including matching and non-matching paths, HTTP verb mismatches, extra path segments, and multiple roles. [[1]](diffhunk://#diff-3ea876f0dd5541545b1079a63374a63758507be88cc685a536acfae3d4a80946R34-R45) [[2]](diffhunk://#diff-3ea876f0dd5541545b1079a63374a63758507be88cc685a536acfae3d4a80946L126-R170) [[3]](diffhunk://#diff-3ea876f0dd5541545b1079a63374a63758507be88cc685a536acfae3d4a80946L140-R250)



Related issue: [VOL-7090](https://dvsa.atlassian.net/browse/VOL-7090)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

[VOL-7090]: https://dvsa.atlassian.net/browse/VOL-7090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ